### PR TITLE
DM-47594: Add Sentry telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,14 @@ update: update-deps init
 
 .PHONY: update-deps
 update-deps:
-	pip install --upgrade uv
-	uv pip install --upgrade pre-commit
-	pre-commit autoupdate
-	uv pip compile --upgrade --generate-hashes			\
+#	pip install --upgrade uv
+#	uv pip install --upgrade pre-commit
+#	pre-commit autoupdate
+	uv pip compile --generate-hashes			\
 	    --output-file requirements/main.txt requirements/main.in
-	uv pip compile --upgrade --generate-hashes			\
+	uv pip compile --generate-hashes			\
 	    --output-file requirements/dev.txt requirements/dev.in
-	uv pip compile --upgrade --generate-hashes			\
+	uv pip compile --generate-hashes			\
 	    --output-file requirements/tox.txt requirements/tox.in
 
 # Useful for testing against a Git version of Safir.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,6 +16,10 @@ anyio==4.6.2.post1 \
     # via
     #   -c requirements/main.txt
     #   httpx
+appnope==0.1.4 \
+    --hash=sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee \
+    --hash=sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c
+    # via ipykernel
 asgi-lifespan==2.1.0 \
     --hash=sha256:5e2effaf0bfe39829cf2d64e7ecc47c7d86d676a6599f7afba378c31f5e3a308 \
     --hash=sha256:ed840706680e28428c01e14afb3875d7d76d3206f3d5b2f2294e059b5c23804f

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -27,4 +27,5 @@ astropy
 vo-models
 defusedxml
 lsst-daf-butler[postgres, remote]
+sentry-sdk
 lsst-dax-obscore

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -653,12 +653,7 @@ jsonschema-specifications==2024.10.1 \
     --hash=sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272 \
     --hash=sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf
     # via jsonschema
-lsst-daf-butler==28.2024.4700 \
-    --hash=sha256:496ab057c9d08cdffbfba6801ad95d9936355a8595e99e9d0767f2f9fb3c65f9 \
-    --hash=sha256:6d3a46859eda595a00d509b215885b6f1396f8b4238ebd4397f43a066f009fc3
-    # via
-    #   -r requirements/main.in
-    #   lsst-dax-obscore
+lsst-daf-butler @ git+https://github.com/lsst/daf_butler@tickets/DM-47889#egg=lsst-daf-butler
 lsst-daf-relation==28.2024.4700 \
     --hash=sha256:95258dd08762212d9f6a8c0c0f55425ba12c893a0e5128463b5990b90e9dda9e \
     --hash=sha256:969425558a55832b36142d03ce27c01df2275ca905ad1df040ea6f3ee60cc054

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -118,6 +118,7 @@ certifi==2024.8.30 \
     #   httpcore
     #   httpx
     #   requests
+    #   sentry-sdk
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
     --hash=sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2 \
@@ -1451,6 +1452,10 @@ safir-logging==6.5.1 \
     --hash=sha256:b056306de26627e29bd6a6d04b1144456a1319ec0e15a67ebbc12b43362a27cd \
     --hash=sha256:ff591f0247fda10842835e714a6dbf601a894432d33d6d98e20fe035a5ad952c
     # via safir
+sentry-sdk==2.18.0 \
+    --hash=sha256:0dc21febd1ab35c648391c664df96f5f79fb0d92d7d4225cd9832e53a617cafd \
+    --hash=sha256:ee70e27d1bbe4cd52a38e1bd28a5fadb9b17bc29d91b5f2b97ae29c0a7610442
+    # via -r requirements/main.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254

--- a/src/sia/main.py
+++ b/src/sia/main.py
@@ -33,6 +33,7 @@ from .exceptions import VOTableError
 from .handlers.external import external_router
 from .handlers.internal import internal_router
 from .middleware.ivoa import CaseInsensitiveFormMiddleware
+from .telemetry import enable_telemetry
 
 __all__ = ["app"]
 
@@ -63,6 +64,7 @@ configure_logging(
     name="sia",
 )
 configure_uvicorn_logging(config.log_level)
+enable_telemetry()
 
 app = FastAPI(
     title="sia",

--- a/src/sia/telemetry.py
+++ b/src/sia/telemetry.py
@@ -1,0 +1,30 @@
+"""Setup code for Sentry.io trace."""
+
+from typing import Any
+
+
+def enable_telemetry() -> None:
+    """Turn on upload of trace telemetry to Sentry, to allow performance
+    debugging of deployed server.
+    """
+    try:
+        import sentry_sdk
+    except ImportError:
+        return
+
+    # Configuration will be pulled from SENTRY_* environment variables
+    # (see https://docs.sentry.io/platforms/python/configuration/options/).
+    # If SENTRY_DSN is not present, telemetry is disabled.
+    sentry_sdk.init(
+        enable_tracing=True, traces_sampler=_decide_whether_to_sample_trace
+    )
+
+
+def _decide_whether_to_sample_trace(context: dict[str, Any]) -> float:
+    asgi_scope = context.get("asgi_scope")
+    if asgi_scope is not None:
+        # Do not log health check endpoint.
+        if asgi_scope.get("path") == "/":
+            return 0
+
+    return 1


### PR DESCRIPTION
Add the Sentry SDK and use it to capture traces for debugging performance problems.

(I probably won't merge this -- just want to make a build for testing.)