### PR TITLE
DM-46975: Read band information from obscore config and fix self-description doc

### DIFF
--- a/changelog.d/20241216_192656_steliosvoutsinas_DM_46975.md
+++ b/changelog.d/20241216_192656_steliosvoutsinas_DM_46975.md
@@ -1,0 +1,6 @@
+<!-- Delete the sections that don't apply -->
+
+### New features
+
+- Now reads bands information from obscore config
+- Fix some of the self-descirption documentation (calibs and remove specify statements)

--- a/src/sia/models/sia_query_params.py
+++ b/src/sia/models/sia_query_params.py
@@ -14,6 +14,7 @@ from ..exceptions import UsageFaultError
 from ..models.common import CaseInsensitiveEnum
 
 __all__ = [
+    "BandInfo",
     "BaseQueryParams",
     "CalibLevel",
     "DPType",
@@ -64,6 +65,48 @@ class Polarization(CaseInsensitiveEnum):
     YY = "YY"
     XY = "XY"
     YX = "YX"
+
+
+@dataclass
+class BandInfo:
+    """A class to represent a band's wavelength range.
+
+    Attributes
+    ----------
+    label
+        The band's label.
+    low
+        The low end of the band's wavelength range.
+    high
+        The high end of the band's wavelength range.
+    """
+
+    label: str
+    low: float
+    high: float
+
+    @property
+    def midpoint(self) -> float:
+        """Calculate the midpoint of the band's wavelength range.
+
+        Returns
+        -------
+        float
+            The midpoint of the band's wavelength range
+        """
+        return (self.low + self.high) / 2
+
+    @property
+    def formatted_midpoint(self) -> str:
+        """Return the midpoint formatted in scientific notation.
+
+        Returns
+        -------
+        str
+            The midpoint formatted in scientific notation
+        """
+        nm_value = self.midpoint * 1e9
+        return f"{nm_value:.1f}e-9"
 
 
 class BaseQueryParams(ABC):

--- a/src/sia/templates/self_description.xml
+++ b/src/sia/templates/self_description.xml
@@ -5,16 +5,18 @@
   <RESOURCE type="meta" utype="adhoc:this">
     <DESCRIPTION>Self description and list of supported parameters</DESCRIPTION>
     <GROUP name="inputParams">
-      <PARAM name="BAND" datatype="double" arraysize="2" unit="m" xtype="interval">
-        <DESCRIPTION>Energy bounds</DESCRIPTION>
+      <PARAM name="BAND" datatype="float" arraysize="2*" xtype="interval">
+        <DESCRIPTION>Wavelength/filter band selection</DESCRIPTION>
+        {%- for band in bands %}
+        <OPTION name="{{ band.label }}" value="{{ band.formatted_midpoint }}"/>
+        {%- endfor %}
       </PARAM>
       <PARAM name="CALIB" datatype="int" arraysize="*">
         <DESCRIPTION>Calibration level</DESCRIPTION>
         <VALUES type="actual">
-          <OPTION value="0"/>
-          <OPTION value="1"/>
-          <OPTION value="2"/>
-          <OPTION value="3"/>
+          <OPTION value="1" name="Raw Data"/>
+          <OPTION value="2" name="PVIs"/>
+          <OPTION value="3" name="Coadds and Difference Images"/>
         </VALUES>
       </PARAM>
       <PARAM name="COLLECTION" datatype="char" arraysize="*">
@@ -81,10 +83,10 @@
         </VALUES>
       </PARAM>
       <PARAM name="SPATRES" datatype="double" arraysize="2" unit="arcsec" xtype="interval">
-        <DESCRIPTION>Specify position resolution</DESCRIPTION>
+        <DESCRIPTION>Position resolution</DESCRIPTION>
       </PARAM>
       <PARAM name="SPECRP" datatype="double" arraysize="2" xtype="interval">
-        <DESCRIPTION>Specify energy resolving power</DESCRIPTION>
+        <DESCRIPTION>Energy resolving power</DESCRIPTION>
       </PARAM>
       <PARAM name="TARGET" datatype="char" arraysize="*">
         <DESCRIPTION>Target name</DESCRIPTION>
@@ -121,7 +123,7 @@
         <DESCRIPTION>Product type (e.g. science, calibration, auxiliary, preview, info)</DESCRIPTION>
       </FIELD>
       <FIELD name="calib_level" datatype="short" ucd="meta.code;obs.calib" utype="obscore:obsdataset.caliblevel">
-        <DESCRIPTION>Calibration level of the observation: in {0, 1, 2, 3, 4}</DESCRIPTION>
+        <DESCRIPTION>Calibration level of the observation: in {1, 2, 3}</DESCRIPTION>
       </FIELD>
       <FIELD name="dataproduct_type" datatype="char" arraysize="*" ucd="meta.id" utype="obscore:obsdataset.dataproducttype">
         <DESCRIPTION>Data product (file content) primary type</DESCRIPTION>

--- a/tests/handlers/external/external_test.py
+++ b/tests/handlers/external/external_test.py
@@ -12,6 +12,7 @@ from httpx import AsyncClient
 
 from sia.config import config
 from sia.constants import RESULT_NAME
+from sia.models.sia_query_params import BandInfo
 from tests.support.butler import MockButler, MockButlerQueryService
 from tests.support.constants import EXCEPTION_MESSAGES
 from tests.support.validators import validate_votable_error
@@ -240,12 +241,29 @@ async def test_query_maxrec_zero(
     )
     templates_dir = Jinja2Templates(template_dir)
 
+    bands = [
+        BandInfo(label="Rubin band HSC-G", low=406.0e-9, high=545.0e-9),
+        BandInfo(label="Rubin band HSC-R", low=543.0e-9, high=693.0e-9),
+        BandInfo(label="Rubin band HSC-R2", low=542.0e-9, high=693.0e-9),
+        BandInfo(label="Rubin band HSC-I", low=690.0e-9, high=842.0e-9),
+        BandInfo(label="Rubin band HSC-I2", low=692.0e-9, high=850.0e-9),
+        BandInfo(label="Rubin band HSC-Z", low=852.0e-9, high=928.0e-9),
+        BandInfo(label="Rubin band HSC-Y", low=937.0e-9, high=1015.0e-9),
+        BandInfo(label="Rubin band N921", low=914.7e-9, high=928.1e-9),
+        BandInfo(label="Rubin band g", low=406.0e-9, high=545.0e-9),
+        BandInfo(label="Rubin band r", low=542.0e-9, high=693.0e-9),
+        BandInfo(label="Rubin band i", low=692.0e-9, high=850.0e-9),
+        BandInfo(label="Rubin band z", low=852.0e-9, high=928.0e-9),
+        BandInfo(label="Rubin band y", low=937.0e-9, high=1015.0e-9),
+    ]
+
     context = {
         "instruments": ["HSC"],
         "collections": ["LSST.CI"],
         "resource_identifier": "ivo://rubin//ci_hsc_gen3",
         "access_url": "https://example.com/api/sia/hsc/query",
         "facility_name": "Subaru",
+        "bands": bands,
     }
 
     template_rendered = templates_dir.get_template(

--- a/tests/models/sia_params_test.py
+++ b/tests/models/sia_params_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from sia.models.common import CaseInsensitiveEnum
 from sia.models.sia_query_params import (
+    BandInfo,
     CalibLevel,
     DPType,
     Polarization,
@@ -133,6 +134,64 @@ async def test_sia_params_default_values() -> None:
     assert params.instrument is None
     assert params.maxrec == 0
     assert params.responseformat is None
+
+
+def test_band_info_initialization() -> None:
+    """Test proper initialization of BandInfo."""
+    band = BandInfo(label="Rubin band u", low=330.0e-9, high=400.0e-9)
+    assert band.label == "Rubin band u"
+    assert band.low == 330.0e-9
+    assert band.high == 400.0e-9
+
+
+def test_band_info_midpoint_calculation() -> None:
+    """Test midpoint calculations for different bands."""
+    band_u = BandInfo(label="Rubin band u", low=330.0e-9, high=400.0e-9)
+    expected_u_midpoint = (330.0e-9 + 400.0e-9) / 2
+    assert band_u.midpoint == expected_u_midpoint
+
+    band_y = BandInfo(label="Rubin band y", low=970.0e-9, high=1060.0e-9)
+    expected_y_midpoint = (970.0e-9 + 1060.0e-9) / 2
+    assert band_y.midpoint == expected_y_midpoint
+
+
+def test_band_info_formatted_midpoint() -> None:
+    """Test formatted midpoint string representations."""
+    test_cases = [
+        {
+            "label": "Rubin band u",
+            "low": 330.0e-9,
+            "high": 400.0e-9,
+            "expected": "365.0e-9",
+        },
+        {
+            "label": "Rubin band g",
+            "low": 402.0e-9,
+            "high": 552.0e-9,
+            "expected": "477.0e-9",
+        },
+        {
+            "label": "Rubin band y",
+            "low": 970.0e-9,
+            "high": 1060.0e-9,
+            "expected": "1015.0e-9",
+        },
+    ]
+
+    for case in test_cases:
+        low = (
+            float(case["low"])
+            if isinstance(case["low"], (int | float))
+            else 0.0
+        )
+        high = (
+            float(case["high"])
+            if isinstance(case["high"], (int | float))
+            else 0.0
+        )
+
+        band = BandInfo(label=str(case["label"]), low=low, high=high)
+        assert band.formatted_midpoint == case["expected"]
 
 
 @pytest.fixture

--- a/tests/templates/self_description.xml
+++ b/tests/templates/self_description.xml
@@ -5,16 +5,18 @@
   <RESOURCE type="meta" utype="adhoc:this">
     <DESCRIPTION>Self description and list of supported parameters</DESCRIPTION>
     <GROUP name="inputParams">
-      <PARAM name="BAND" datatype="double" arraysize="2" unit="m" xtype="interval">
-        <DESCRIPTION>Energy bounds</DESCRIPTION>
+      <PARAM name="BAND" datatype="float" arraysize="2*" xtype="interval">
+        <DESCRIPTION>Wavelength/filter band selection</DESCRIPTION>
+        {%- for band in bands %}
+        <OPTION name="{{ band.label }}" value="{{ band.formatted_midpoint }}"/>
+        {%- endfor %}
       </PARAM>
       <PARAM name="CALIB" datatype="int" arraysize="*">
         <DESCRIPTION>Calibration level</DESCRIPTION>
         <VALUES type="actual">
-          <OPTION value="0"/>
-          <OPTION value="1"/>
-          <OPTION value="2"/>
-          <OPTION value="3"/>
+          <OPTION value="1" name="Raw Data"/>
+          <OPTION value="2" name="PVIs"/>
+          <OPTION value="3" name="Coadds and Difference Images"/>
         </VALUES>
       </PARAM>
       <PARAM name="COLLECTION" datatype="char" arraysize="*">
@@ -81,10 +83,10 @@
         </VALUES>
       </PARAM>
       <PARAM name="SPATRES" datatype="double" arraysize="2" unit="arcsec" xtype="interval">
-        <DESCRIPTION>Specify position resolution</DESCRIPTION>
+        <DESCRIPTION>Position resolution</DESCRIPTION>
       </PARAM>
       <PARAM name="SPECRP" datatype="double" arraysize="2" xtype="interval">
-        <DESCRIPTION>Specify energy resolving power</DESCRIPTION>
+        <DESCRIPTION>Energy resolving power</DESCRIPTION>
       </PARAM>
       <PARAM name="TARGET" datatype="char" arraysize="*">
         <DESCRIPTION>Target name</DESCRIPTION>
@@ -121,7 +123,7 @@
         <DESCRIPTION>Product type (e.g. science, calibration, auxiliary, preview, info)</DESCRIPTION>
       </FIELD>
       <FIELD name="calib_level" datatype="short" ucd="meta.code;obs.calib" utype="obscore:obsdataset.caliblevel">
-        <DESCRIPTION>Calibration level of the observation: in {0, 1, 2, 3, 4}</DESCRIPTION>
+        <DESCRIPTION>Calibration level of the observation: in {1, 2, 3}</DESCRIPTION>
       </FIELD>
       <FIELD name="dataproduct_type" datatype="char" arraysize="*" ucd="meta.id" utype="obscore:obsdataset.dataproducttype">
         <DESCRIPTION>Data product (file content) primary type</DESCRIPTION>


### PR DESCRIPTION
**Summary**

Addresses JIRA ticket DM-46975 related to the self-description metadata generation by:
- Now reads band information from obscore configuration and converts it to the expected output (value is midpoint between ranges). Added BandInfo model to help parse from obscore into the template response.
- Remove specify statements
- Fix output of Calibs (Remove 0 & 4)
- Add test cases for above
