### PR TITLE
DM-48938: Capture sia query in sentry tracing

### DIFF
--- a/src/sia/constants.py
+++ b/src/sia/constants.py
@@ -1,6 +1,11 @@
 """Constants for the SIA service."""
 
-__all__ = ["RESPONSEFORMATS", "RESULT_NAME", "SINGLE_PARAMS"]
+__all__ = [
+    "BASE_RESOURCE_IDENTIFIER",
+    "RESPONSEFORMATS",
+    "RESULT_NAME",
+    "SINGLE_PARAMS",
+]
 
 RESPONSEFORMATS = {"votable", "application/x-votable"}
 """List of supported response formats for the SIA service."""


### PR DESCRIPTION
### Summary

We need to gather more info in the Sentry traces than appear with the default instrumentation to better understand query execution process and any scalability bottlenecks. This PR addresses this by initially adding capturing the query method as a span and adding some data to identify the query that was run,