### PR TITLE
DM-49297: Enable Sentry metrics (events) for SIA queries

### DIFF
--- a/src/sia/config.py
+++ b/src/sia/config.py
@@ -7,6 +7,7 @@ from typing import Annotated, Self
 from pydantic import Field, HttpUrl, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.logging import LogLevel, Profile
+from safir.metrics import MetricsConfiguration, metrics_configuration_factory
 
 from .models.data_collections import ButlerDataCollection
 
@@ -31,6 +32,13 @@ class Config(BaseSettings):
         LogLevel.INFO, title="Log level of the application's logger"
     )
     """Log level of the application's logger."""
+
+    metrics: MetricsConfiguration = Field(
+        default_factory=metrics_configuration_factory,
+        title="Metrics configuration",
+        description="Configuration for reporting metrics to Kafka",
+    )
+    """Configuration for reporting metrics to Kafka."""
 
     model_config = SettingsConfigDict(env_prefix="SIA_", case_sensitive=False)
     """Configuration for the model settings."""

--- a/src/sia/events.py
+++ b/src/sia/events.py
@@ -7,11 +7,17 @@ from safir.dependencies.metrics import EventMaker
 from safir.metrics import EventManager, EventPayload
 
 
-class SIAQuery(EventPayload):
-    """Reported when a SIA query is executed."""
+class SIAQuerySucceeded(EventPayload):
+    """Reported when a SIA query is successfully executed."""
 
-    success: bool
+    duration: timedelta
+
+
+class SIAQueryFailed(EventPayload):
+    """Reported when a SIA query fails."""
+
     duration: timedelta | None
+    error: str | None = None
 
 
 class Events(EventMaker):
@@ -19,4 +25,9 @@ class Events(EventMaker):
 
     @override
     async def initialize(self, manager: EventManager) -> None:
-        self.sia_query = await manager.create_publisher("sia_query", SIAQuery)
+        self.sia_query_succeeded = await manager.create_publisher(
+            "sia_query_succeeded", SIAQuerySucceeded
+        )
+        self.sia_query_failed = await manager.create_publisher(
+            "sia_query_failed", SIAQueryFailed
+        )

--- a/src/sia/events.py
+++ b/src/sia/events.py
@@ -1,0 +1,22 @@
+"""App metrics events."""
+
+from datetime import timedelta
+from typing import override
+
+from safir.dependencies.metrics import EventMaker
+from safir.metrics import EventManager, EventPayload
+
+
+class SIAQuery(EventPayload):
+    """Reported when a SIA query is executed."""
+
+    success: bool
+    duration: timedelta | None
+
+
+class Events(EventMaker):
+    """Container for app metrics event publishers."""
+
+    @override
+    async def initialize(self, manager: EventManager) -> None:
+        self.sia_query = await manager.create_publisher("sia_query", SIAQuery)

--- a/src/sia/handlers/external.py
+++ b/src/sia/handlers/external.py
@@ -192,5 +192,6 @@ def query(
         token=delegated_token,
         sia_query=siav2_query,
         collection=collection,
-        context=context,
+        events=context.events,
+        request=context.request,
     )

--- a/src/sia/handlers/external.py
+++ b/src/sia/handlers/external.py
@@ -192,5 +192,5 @@ def query(
         token=delegated_token,
         sia_query=siav2_query,
         collection=collection,
-        request=context.request,
+        context=context,
     )

--- a/src/sia/main.py
+++ b/src/sia/main.py
@@ -50,13 +50,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     logger.debug("SIA has started up.")
     await labeled_butler_factory_dependency.initialize(config=config)
     await obscore_config_dependency.initialize(config=config)
-    await context_dependency.initialize(config=config)
+    event_manager = config.metrics.make_manager()
+    await event_manager.initialize()
+    await context_dependency.initialize(
+        config=config, event_manager=event_manager
+    )
 
     yield
 
     await labeled_butler_factory_dependency.aclose()
     await obscore_config_dependency.aclose()
     await context_dependency.aclose()
+    await event_manager.aclose()
     await http_client_dependency.aclose()
     logger.debug("SIA shut down complete.")
 

--- a/src/sia/services/response_handler.py
+++ b/src/sia/services/response_handler.py
@@ -201,6 +201,7 @@ class ResponseHandlerService:
                         SIAQueryFailed(error=str(e), duration=duration(span))
                     )
                 )
+                raise
 
             # Convert the result to a string
             result = VotableConverterService(table_as_votable).to_string()

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ setenv =
     "name":"dp02", "label":"LSST.DP02", "butler_type":"REMOTE", \
     "repository":"https://example.com/repo/dp02/butler.yaml"}]
     SIA_ENVIRONMENT_NAME = testing
+    METRICS_ENABLED = false
+    METRICS_APPLICATION = "sia"
+    METRICS_MOCK = true
 
 [testenv:coverage-report]
 description = Compile coverage from each test run.


### PR DESCRIPTION
Enables blue-end metrics for SIAv2, so that we record the SIAv2 query event, i.e. its status and duration.