### PR TITLE
DM-49297: Make SIA query handler asynchronous

### DIFF
--- a/src/sia/handlers/external.py
+++ b/src/sia/handlers/external.py
@@ -178,7 +178,7 @@ async def get_capabilities(
     },
     summary="IVOA SIA (v2) service query (POST)",
 )
-def query(
+async def query(
     *,
     context: Annotated[RequestContext, Depends(context_dependency)],
     collection: Annotated[ButlerDataCollection, Depends(validate_collection)],
@@ -188,7 +188,7 @@ def query(
         str | None, Depends(optional_auth_delegated_token_dependency)
     ],
 ) -> Response:
-    return ResponseHandlerService.process_query(
+    return await ResponseHandlerService.process_query(
         factory=context.factory,
         params=params,
         token=delegated_token,


### PR DESCRIPTION
## Summary

Calling out to an async from a sync method seems complicated. This was needed in order to use the underlying Safir metrics event publisher which needs to be called asynchronously.

To address this the PR switches the query handling route & methods to be async, and uses run_in_executor for methods that are sync, like the butler calls.