### PR TITLE
DM-51390: Enable reading in dataproduct subtypes from obscore config for self-description

### DIFF
--- a/src/sia/services/response_handler.py
+++ b/src/sia/services/response_handler.py
@@ -66,6 +66,29 @@ class ResponseHandlerService:
         return bands
 
     @staticmethod
+    def _get_dataproduct_subtypes(
+        obscore_config: ExporterConfig,
+    ) -> list[str]:
+        """Extract unique dataproduct subtypes from dataset types.
+
+        Parameters
+        ----------
+        obscore_config
+            The ExporterConfig object containing dataset types.
+
+        Returns
+        -------
+        list[str]
+            The list of unique dataproduct subtypes.
+        """
+        subtypes = {
+            config.dataproduct_subtype
+            for config in obscore_config.dataset_types.values()
+            if config.dataproduct_subtype is not None
+        }
+        return list(subtypes)
+
+    @staticmethod
     async def self_description_response(
         request: Request,
         butler: Butler,
@@ -96,6 +119,10 @@ class ResponseHandlerService:
             obscore_config.spectral_ranges
         )
 
+        dataproduct_subtypes = (
+            ResponseHandlerService._get_dataproduct_subtypes(obscore_config)
+        )
+
         return _TEMPLATES.TemplateResponse(
             request,
             "self_description.xml",
@@ -115,6 +142,7 @@ class ResponseHandlerService:
                 ),
                 "facility_name": obscore_config.facility_name.strip(),
                 "bands": bands,
+                "dataproduct_subtypes": dataproduct_subtypes,
             },
             headers={
                 "content-disposition": f"attachment; filename={RESULT}.xml",

--- a/src/sia/templates/self_description.xml
+++ b/src/sia/templates/self_description.xml
@@ -34,6 +34,14 @@
           <OPTION value="image"/>
         </VALUES>
       </PARAM>
+      <PARAM name="DPSUBTYPE" datatype="char" arraysize="*">
+        <DESCRIPTION>Value of dataproduct subtype</DESCRIPTION>
+        <VALUES type="actual">
+          {%- for dpsubtype in dataproduct_subtypes|sort  %}
+          <OPTION value="{{ dpsubtype }}"/>
+          {%- endfor %}
+        </VALUES>
+      </PARAM>
       <PARAM name="EXPTIME" datatype="double" arraysize="2" unit="sec" xtype="interval">
         <DESCRIPTION>Range of exposure times</DESCRIPTION>
       </PARAM>

--- a/tests/handlers/external/external_test.py
+++ b/tests/handlers/external/external_test.py
@@ -260,6 +260,7 @@ async def test_query_maxrec_zero(
     context = {
         "instruments": ["HSC"],
         "collections": ["LSST.CI"],
+        "dataproduct_subtypes": ["lsst.coadd", "lsst.raw", "lsst.calexp"],
         "resource_identifier": "ivo://rubin//ci_hsc_gen3",
         "access_url": "https://example.com/api/sia/hsc/query",
         "facility_name": "Subaru",

--- a/tests/templates/self_description.xml
+++ b/tests/templates/self_description.xml
@@ -34,6 +34,14 @@
           <OPTION value="image"/>
         </VALUES>
       </PARAM>
+      <PARAM name="DPSUBTYPE" datatype="char" arraysize="*">
+        <DESCRIPTION>Value of dataproduct subtype</DESCRIPTION>
+        <VALUES type="actual">
+          {%- for dpsubtype in dataproduct_subtypes|sort  %}
+          <OPTION value="{{ dpsubtype }}"/>
+          {%- endfor %}
+        </VALUES>
+      </PARAM>
       <PARAM name="EXPTIME" datatype="double" arraysize="2" unit="sec" xtype="interval">
         <DESCRIPTION>Range of exposure times</DESCRIPTION>
       </PARAM>


### PR DESCRIPTION
Since we are now allowing the dataproduct subtype as an additional query parameter we should show this in the self-description document returned by MAXREC=0. To do this in this PR I parse the Obscore config and collect the list from there.