### PR TITLE
DM-55537: Tidy up Pydantic models

### DIFF
--- a/src/sia/config.py
+++ b/src/sia/config.py
@@ -18,37 +18,12 @@ __all__ = ["Config", "config"]
 class Config(BaseSettings):
     """Configuration for sia."""
 
-    name: str = Field("sia", title="Name of application")
-    """Name of application."""
-
-    path_prefix: str = Field("/api/sia", title="URL prefix for application")
-    """URL prefix for application."""
-
-    profile: Profile = Field(
-        Profile.development, title="Application logging profile"
-    )
-    """Application logging profile."""
-
-    log_level: LogLevel = Field(
-        LogLevel.INFO, title="Log level of the application's logger"
-    )
-    """Log level of the application's logger."""
-
-    metrics: MetricsConfiguration = Field(
-        default_factory=metrics_configuration_factory,
-        title="Metrics configuration",
-        description="Configuration for reporting metrics to Kafka",
-    )
-    """Configuration for reporting metrics to Kafka."""
-
     model_config = SettingsConfigDict(env_prefix="SIA_", case_sensitive=False)
-    """Configuration for the model settings."""
 
     butler_data_collections: Annotated[
         list[ButlerDataCollection],
         Field(title="Data collections"),
     ]
-    """Configuration for the data collections."""
 
     environment_name: Annotated[
         str,
@@ -59,12 +34,24 @@ class Config(BaseSettings):
             ),
         ),
     ]
-    """The environment name in Phalanx."""
 
-    slack_webhook: Annotated[
-        HttpUrl | None, Field(title="Slack webhook for exception reporting")
-    ] = None
-    """Slack webhook for exception reporting."""
+    log_level: LogLevel = Field(
+        LogLevel.INFO, title="Log level of the application's logger"
+    )
+
+    metrics: MetricsConfiguration = Field(
+        default_factory=metrics_configuration_factory,
+        title="Metrics configuration",
+        description="Configuration for reporting metrics to Kafka",
+    )
+
+    name: str = Field("sia", title="Name of application")
+
+    path_prefix: str = Field("/api/sia", title="URL prefix for application")
+
+    profile: Profile = Field(
+        Profile.development, title="Application logging profile"
+    )
 
     sentry_dsn: Annotated[
         str | None,
@@ -73,7 +60,6 @@ class Config(BaseSettings):
             description="DSN for sending events to Sentry.",
         ),
     ] = None
-    """DSN for sending events to Sentry."""
 
     sentry_traces_sample_rate: Annotated[
         float,
@@ -88,7 +74,10 @@ class Config(BaseSettings):
             le=1,
         ),
     ] = 0
-    """The percentage of transactions to send to Sentry."""
+
+    slack_webhook: Annotated[
+        HttpUrl | None, Field(title="Slack webhook for exception reporting")
+    ] = None
 
     @model_validator(mode="after")
     def _validate_butler_data_collections(self) -> Self:

--- a/src/sia/models/data_collections.py
+++ b/src/sia/models/data_collections.py
@@ -19,69 +19,73 @@ class ButlerDataCollection:
     config: Annotated[
         HttpUrl | Path,
         Field(
-            description="Config Path or URL to obscore config for collection",
+            title="ObsCore configuration",
+            description="Config path or URL to obscore config for collection",
             examples=[
                 "https://example.com/butler-repo/path/to/local/dp02.yaml",
                 "/path/to/local/butler/dp02.yaml",
             ],
         ),
     ]
-    """The obscore configuration file for this data collection."""
 
     repository: Annotated[
         HttpUrl | Path,
         Field(
-            description="Butler Repository Path or URL",
+            title="Butler repository",
+            description="Butler repository path or URL",
             examples=[
                 "https://example.com/butler-repo/path/to/local/repository",
                 "/path/to/local/butler/repository",
             ],
         ),
     ]
-    """Butler Repository Path or URL"""
 
     label: Annotated[
         str,
         Field(
-            description="The label for this Butler collection. Used to "
-            "identify the collection in the case where we are "
-            "using a Remote Butler",
+            title="Butler label",
+            description=(
+                "The label for this Butler collection. Used to identify the"
+                " collection in the case where we are using a remote Butler."
+            ),
             examples=["LSST.DP02"],
         ),
     ]
-    """The label for this Butler collection"""
 
     name: Annotated[
         str,
         Field(
-            description="The name for this Butler collection. This value is "
-            "used to identify the collection in API URLs. "
-            "For example, a name of 'dp02' would be used in the URL "
-            "'/api/sia/dp02/query'.",
+            title="Name of Butler collection",
+            description=(
+                "The name for this Butler collection. This value is used to"
+                " identify the collection in API URLs. For example, a name of"
+                " 'dp02' would be used in the URL '/api/sia/dp02/query'."
+            ),
             examples=["dp02"],
         ),
     ]
-    """The name for this Butler collection."""
 
     butler_type: Annotated[
         ButlerType,
         Field(
+            title="Butler type",
             description="The Butler type for this data collection.",
             examples=["REMOTE", "DIRECT"],
         ),
     ]
-    """The Butler type for this data collection."""
 
     datalink_url: Annotated[
         HttpUrl | None,
         Field(
             default=None,
-            description="An optional datalink URL to use instead of the one "
-            "in the config. This will overwrite the value in the obscore "
-            "configuration for the collection",
+            title="DataLink URL",
+            description=(
+                "An optional datalink URL to use instead of the one in the"
+                " config. This will overwrite the value in the obscore"
+                " configuration for the collection"
+            ),
         ),
     ] = None
-    """An optional datalink URL to use instead of the one in the config"""
 
     @property
     def identifier(self) -> str:

--- a/src/sia/models/sia_query_params.py
+++ b/src/sia/models/sia_query_params.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from enum import Enum
 from numbers import Integral
-from typing import Annotated, Any, Self, TypeVar, cast, override
+from typing import Annotated, Any, Self, cast, override
 
 from fastapi import Query
 from lsst.dax.obscore.siav2 import (
@@ -23,8 +23,6 @@ __all__ = [
     "SIAQueryParams",
     "Shape",
 ]
-
-T = TypeVar("T", bound=Enum)
 
 MAXREC_LIMIT: int = 60000
 


### PR DESCRIPTION
Alphabetize the settings in `Config`, move `model_config` to the top of the class definition, remove an unused `TypeVar`, and remove docstrings from Pydantic fields in favor of populating the `title` attribute.