### PR TITLE
DM-55537: Update how Docker package installs are handled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@
 #   Updates the base Python image with security patches and common system
 #   packages. This image becomes the base of all other images.
 # install-image
-#   Installs third-party dependencies (requirements/main.txt) and the
-#   application into a virtual environment. This virtual environment is
-#   ideal for copying across build stages.
+#   Installs dependencies and the application into a virtual environment.
+#   This virtual environment is ideal for copying across build stages.
 # runtime-image
 #   - Copies the virtual environment into place.
 #   - Runs a non-root user.
@@ -16,7 +15,9 @@ FROM python:3.14.6-slim-bookworm AS base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .
-RUN ./install-base-packages.sh && rm ./install-base-packages.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    ./install-base-packages.sh && rm ./install-base-packages.sh
 
 FROM base-image AS install-image
 
@@ -25,7 +26,9 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.30 /uv /bin/uv
 
 # Install system packages only needed for building dependencies.
 COPY scripts/install-dependency-packages.sh .
-RUN ./install-dependency-packages.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    ./install-dependency-packages.sh
 
 # Disable hard links during uv package installation since we're using a
 # cache on a separate file system.

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -1,38 +1,29 @@
 #!/bin/bash
 
-# This script updates packages in the base Docker image that's used by both the
-# build and runtime images, and gives us a place to install additional
+# This script updates packages in the base Docker image that's used by both
+# the build and runtime images, and gives us a place to install additional
 # system-level packages with apt-get.
 #
 # Based on the blog post:
 # https://pythonspeed.com/articles/system-packages-docker/
 
-# Bash "strict mode", to help catch problems and bugs in the shell
-# script. Every bash script you write should include this. See
-# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for
-# details.
+# Bash "strict mode", to help catch problems and bugs in the shell script.
+# Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
 # Display each command as it's run.
 set -x
 
-# Tell apt-get we're never going to be able to give manual
-# feedback:
+# Tell apt-get we're never going to be able to give manual feedback.
 export DEBIAN_FRONTEND=noninteractive
 
-# Update the package listing, so we know what packages exist:
+# Update the package listing, so we know what packages exist.
 apt-get update
 
-# Install security updates:
+# Install security updates.
 apt-get -y upgrade
 
-# libpq-dev is required by psycopg2.
-apt-get -y install --no-install-recommends curl unzip libpq-dev zlib1g-dev
-
-
-# Example of installing a new package, without unnecessary packages:
-apt-get -y install --no-install-recommends git
-
-# Delete cached files we don't need anymore:
-apt-get clean
-rm -rf /var/lib/apt/lists/*
+# Install dependencies required at runtime.
+# libpq-dev: required by psycopg2 (not clear why this is needed?)
+apt-get -y install --no-install-recommends curl libpq-dev unzip zlib1g-dev

--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -8,27 +8,21 @@
 # will be reused by the runtime image, we unfortunately have to do another
 # apt-get update here, which wastes some time and network.
 
-# Bash "strict mode", to help catch problems and bugs in the shell
-# script. Every bash script you write should include this. See
-# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for
-# details.
+# Bash "strict mode", to help catch problems and bugs in the shell script.
+# Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
 # Display each command as it's run.
 set -x
 
-# Tell apt-get we're never going to be able to give manual
-# feedback:
+# Tell apt-get we're never going to be able to give manual feedback.
 export DEBIAN_FRONTEND=noninteractive
 
-# Update the package listing, so we know what packages exist:
+# Update the package listing, so we know what packages exist.
 apt-get update
 
 # Install build-essential because sometimes Python dependencies need to build
-# C modules, particularly when upgrading to newer Python versions.  libffi-dev
+# C modules, particularly when upgrading to newer Python versions. libffi-dev
 # is sometimes needed to build cffi (a cryptography dependency).
 apt-get -y install --no-install-recommends build-essential git libffi-dev
-
-# Delete cached files we don't need anymore:
-apt-get clean
-rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Use cache directories for apt in the Docker install so that the scripts don't have to clean up after themselves. Remove git from the base image, since it should only be required at install time.