### PR TITLE
DM-55537: Change AsyncIterator to AsyncGenerator

### DIFF
--- a/src/sia/main.py
+++ b/src/sia/main.py
@@ -8,7 +8,7 @@ called.
 """
 
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from importlib.metadata import metadata, version
 
@@ -45,7 +45,7 @@ enable_sentry()
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Set up and tear down the application."""
     logger.debug("SIA has started up.")
     await labeled_butler_factory_dependency.initialize(config=config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncGenerator, Iterator
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
@@ -29,7 +29,7 @@ BASE_PATH = Path(__file__).parent
 
 
 @pytest_asyncio.fixture
-async def app(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[FastAPI]:
+async def app(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
@@ -74,7 +74,7 @@ async def app(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[FastAPI]:
 
 
 @pytest_asyncio.fixture
-async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
+async def client(app: FastAPI) -> AsyncGenerator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
     async with AsyncClient(
         transport=ASGITransport(app=app),
@@ -90,7 +90,7 @@ async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
 @pytest_asyncio.fixture
 async def app_direct(
     monkeypatch: pytest.MonkeyPatch,
-) -> AsyncIterator[FastAPI]:
+) -> AsyncGenerator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
@@ -117,7 +117,7 @@ async def app_direct(
 
 
 @pytest_asyncio.fixture
-async def client_direct(app_direct: FastAPI) -> AsyncIterator[AsyncClient]:
+async def client_direct(app_direct: FastAPI) -> AsyncGenerator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
     async with AsyncClient(
         transport=ASGITransport(app=app_direct),


### PR DESCRIPTION
Python async methods with yield have an actual type of `AsyncGenerator`, not `AsyncIterator`, becasue they have a hidden `aclose` method. Fix the types to be more accurate.