### PR TITLE
DM-55537: Add an explicit dependency on structlog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,6 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.29
+    rev: 0.11.30
     hooks:
       - id: uv-lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "python-multipart",
     "requests",
     "safir[kafka]>=14.1.2",
+    "structlog",
     "uvicorn[standard]",
     "vo-models",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2580,6 +2580,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "requests" },
     { name = "safir", extra = ["kafka"] },
+    { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "vo-models" },
 ]
@@ -2628,6 +2629,7 @@ requires-dist = [
     { name = "python-multipart" },
     { name = "requests" },
     { name = "safir", extras = ["kafka"], specifier = ">=14.1.2" },
+    { name = "structlog" },
     { name = "uvicorn", extras = ["standard"] },
     { name = "vo-models" },
 ]


### PR DESCRIPTION
This doesn't change anything about the calculated dependencies since Safir also depends on structlog, but it should be a direct dependency since the package uses imports it directly.