### PR TITLE
DM-55537: Publish multi-platform images for amd64 and arm64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,27 +127,22 @@ jobs:
         run: uv run --only-group=nox nox -s docs-linkcheck
 
   build:
-    runs-on: ubuntu-latest
+    concurrency:
+      group: packages
+      queue: max
     needs: [test]
-    timeout-minutes: 10
+    secrets: inherit
+    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
+    with:
+      images: ghcr.io/${{ github.repository }}
 
     # Only do Docker builds of tagged releases and pull requests from ticket
-    # branches.  This will still trigger on pull requests from untrusted
+    # branches. This will still trigger on pull requests from untrusted
     # repositories whose branch names match our tickets/* branch convention,
     # but in this case the build will fail with an error since the secret
     # won't be set.
     if: >
-      github.event_name != 'merge_group'
-      && (startsWith(github.ref, 'refs/tags/')
-          || startsWith(github.head_ref, 'tickets/'))
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - uses: lsst-sqre/build-and-push-to-ghcr@v1
-        id: build
-        with:
-          image: ${{ github.repository }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      (github.event_name == 'release' && github.event.action == 'published')
+      || (github.event_name != 'merge_group'
+          && (startsWith(github.head_ref, 'tickets/')
+              || startsWith(github.head_ref, 't/')))

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.14.6-slim-bookworm AS base-image
+FROM python:3.14.6-slim-trixie AS base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .

--- a/changelog.d/20260720_160403_rra_DM_55537.md
+++ b/changelog.d/20260720_160403_rra_DM_55537.md
@@ -1,0 +1,3 @@
+### New features
+
+- Publish multi-platform images that support both linux/amd64 and linux/arm64.


### PR DESCRIPTION
In preparation for running the Rubin Science Platform on arm64 hardware, publish multi-platform images. Update the Docker base image to trixie, the current Debian stable release.