### PR TITLE
DM-55537: Rename profile to log_profile

### DIFF
--- a/src/sia/config.py
+++ b/src/sia/config.py
@@ -49,7 +49,7 @@ class Config(BaseSettings):
 
     path_prefix: str = Field("/api/sia", title="URL prefix for application")
 
-    profile: Profile = Field(
+    log_profile: Profile = Field(
         Profile.development, title="Application logging profile"
     )
 

--- a/src/sia/main.py
+++ b/src/sia/main.py
@@ -67,7 +67,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
 
 configure_logging(
-    profile=config.profile,
+    profile=config.log_profile,
     log_level=config.log_level,
     name="sia",
 )


### PR DESCRIPTION
Change the configuration setting `profile` to `log_profile` to more accurately represent what it means and to match the Phalanx chart parameter.