### PR TITLE
DM-55537: Remove deprecated annotation handling

### DIFF
--- a/src/sia/config.py
+++ b/src/sia/config.py
@@ -1,7 +1,5 @@
 """Configuration definition."""
 
-from __future__ import annotations
-
 from typing import Annotated, Self
 
 from pydantic import Field, HttpUrl, model_validator

--- a/src/sia/factory.py
+++ b/src/sia/factory.py
@@ -1,7 +1,5 @@
 """Component factory and process-wide status for sia."""
 
-from __future__ import annotations
-
 import structlog
 from lsst.daf.butler import Butler, LabeledButlerFactory
 from lsst.dax.obscore import ExporterConfig

--- a/src/sia/sentry.py
+++ b/src/sia/sentry.py
@@ -1,7 +1,5 @@
 """Sentry integration helpers."""
 
-from __future__ import annotations
-
 import re
 from collections.abc import Callable, Generator
 from contextlib import contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 """Test fixtures for sia tests."""
 
-from __future__ import annotations
-
 from collections.abc import AsyncGenerator, Iterator
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock

--- a/tests/handlers/external/external_test.py
+++ b/tests/handlers/external/external_test.py
@@ -1,7 +1,5 @@
 """Tests for the sia.handlers.external module and routes."""
 
-from __future__ import annotations
-
 import re
 from pathlib import Path
 from typing import Any

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -1,7 +1,5 @@
 """Tests for the sia.handlers.internal module and routes."""
 
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/models/sia_params_test.py
+++ b/tests/models/sia_params_test.py
@@ -1,7 +1,5 @@
 """Tests for cutout parameter models."""
 
-from __future__ import annotations
-
 import pytest
 
 from sia.models.common import CaseInsensitiveEnum


### PR DESCRIPTION
Remove `from __future__ import annotations` from all files. This is deprecated in Python and is slowly being removed.