### PR TITLE
DM-55537: Stop passing Config around as a parameter

### DIFF
--- a/src/sia/dependencies/context.py
+++ b/src/sia/dependencies/context.py
@@ -14,7 +14,6 @@ from safir.dependencies.logger import logger_dependency
 from safir.metrics import EventManager
 from structlog.stdlib import BoundLogger
 
-from ..config import Config
 from ..events import Events
 from ..factory import Factory
 from .labeled_butler_factory import labeled_butler_factory_dependency
@@ -39,9 +38,6 @@ class RequestContext:
 
     request: Request
     """The incoming request."""
-
-    config: Config
-    """SIA's configuration."""
 
     logger: BoundLogger
     """The request logger, rebound with discovered context."""
@@ -74,7 +70,6 @@ class ContextDependency:
     """
 
     def __init__(self) -> None:
-        self._config: Config | None = None
         self._events: Events | None = None
 
     async def __call__(
@@ -84,12 +79,11 @@ class ContextDependency:
         logger: Annotated[BoundLogger, Depends(logger_dependency)],
     ) -> RequestContext:
         """Create a per-request context and return it."""
-        if not self._config or not self._events:
+        if not self._events:
             raise RuntimeError("ContextDependency not initialized")
 
         return RequestContext(
             request=request,
-            config=self._config,
             logger=logger,
             factory=await self.create_factory(logger=logger),
             events=self._events,
@@ -97,33 +91,20 @@ class ContextDependency:
 
     async def create_factory(self, logger: BoundLogger) -> Factory:
         """Create a factory for use outside a request context."""
-        if not self._config:
-            raise RuntimeError("ContextDependency not initialized")
-
         return Factory(
             logger=logger,
-            config=self._config,
             labeled_butler_factory=await labeled_butler_factory_dependency(),
             obscore_configs=await obscore_config_dependency(),
         )
 
-    async def aclose(self) -> None:
-        """Clean up the per-process configuration."""
-        self._config = None
-
-    async def initialize(
-        self, config: Config, event_manager: EventManager
-    ) -> None:
+    async def initialize(self, event_manager: EventManager) -> None:
         """Initialize the process-wide shared context.
 
         Parameters
         ----------
-        config
-            SIA configuration.
         event_manager
             Global event manager.
         """
-        self._config = config
         self._events = Events()
         await self._events.initialize(event_manager)
 

--- a/src/sia/dependencies/labeled_butler_factory.py
+++ b/src/sia/dependencies/labeled_butler_factory.py
@@ -2,7 +2,6 @@
 
 from lsst.daf.butler import LabeledButlerFactory
 
-from ..config import Config
 from ..services.data_collections import DataCollectionService
 
 
@@ -12,16 +11,11 @@ class LabeledButlerFactoryDependency:
     def __init__(self) -> None:
         self._labeled_butler_factory: LabeledButlerFactory | None = None
 
-    async def initialize(
-        self,
-        config: Config,
-    ) -> None:
+    async def initialize(self) -> None:
         """Initialize the dependency."""
         # Get the data repositories from the config in a format suitable for
         # the LabeledButlerFactory.
-        data_repositories = DataCollectionService(
-            config=config
-        ).get_data_repositories()
+        data_repositories = DataCollectionService().get_data_repositories()
 
         self._labeled_butler_factory = LabeledButlerFactory(
             repositories=data_repositories

--- a/src/sia/dependencies/obscore_configs.py
+++ b/src/sia/dependencies/obscore_configs.py
@@ -2,7 +2,7 @@
 
 from lsst.dax.obscore import ExporterConfig
 
-from ..config import Config
+from ..config import config
 
 
 class ObscoreConfigDependency:
@@ -13,7 +13,7 @@ class ObscoreConfigDependency:
     def __init__(self) -> None:
         self._config_mapping: dict[str, ExporterConfig] | None = None
 
-    async def initialize(self, config: Config) -> None:
+    async def initialize(self) -> None:
         """Initialize the dependency by processing the Butler Collections."""
         self._config_mapping = {}
         for collection in config.butler_data_collections:

--- a/src/sia/factory.py
+++ b/src/sia/factory.py
@@ -5,7 +5,7 @@ from lsst.daf.butler import Butler, LabeledButlerFactory
 from lsst.dax.obscore import ExporterConfig
 from structlog.stdlib import BoundLogger
 
-from .config import Config
+from .config import config
 from .models.data_collections import ButlerDataCollection
 from .services.data_collections import DataCollectionService
 
@@ -20,8 +20,6 @@ class Factory:
 
     Parameters
     ----------
-    config
-        The configuration instance
     labeled_butler_factory
         The LabeledButlerFactory singleton
     obscore_configs
@@ -32,15 +30,13 @@ class Factory:
 
     def __init__(
         self,
-        config: Config,
         labeled_butler_factory: LabeledButlerFactory,
         obscore_configs: dict[str, ExporterConfig],
         logger: BoundLogger | None = None,
     ) -> None:
-        self._config = config
         self._labeled_butler_factory = labeled_butler_factory
         self._obscore_configs = obscore_configs
-        self._logger = logger or structlog.get_logger(self._config.name)
+        self._logger = logger or structlog.get_logger(config.name)
 
     def create_butler(
         self,
@@ -88,9 +84,7 @@ class Factory:
         DataCollectionService
             The data collection service.
         """
-        return DataCollectionService(
-            config=self._config,
-        )
+        return DataCollectionService()
 
     def set_logger(self, logger: BoundLogger) -> None:
         """Replace the internal logger.

--- a/src/sia/handlers/external.py
+++ b/src/sia/handlers/external.py
@@ -95,9 +95,9 @@ async def get_index(
 )
 async def get_availability(collection_name: str) -> Response:
     # Get the butler data collection
-    collection = DataCollectionService(
-        config=config
-    ).get_data_collection_by_name(name=collection_name)
+    collection = DataCollectionService().get_data_collection_by_name(
+        name=collection_name
+    )
 
     # Check if it is available
     availability = await AvailabilityService(

--- a/src/sia/main.py
+++ b/src/sia/main.py
@@ -49,19 +49,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Set up and tear down the application."""
     logger = structlog.get_logger("sia")
     logger.debug("SIA has started up.")
-    await labeled_butler_factory_dependency.initialize(config=config)
-    await obscore_config_dependency.initialize(config=config)
+    await labeled_butler_factory_dependency.initialize()
+    await obscore_config_dependency.initialize()
     event_manager = config.metrics.make_manager()
     await event_manager.initialize()
-    await context_dependency.initialize(
-        config=config, event_manager=event_manager
-    )
+    await context_dependency.initialize(event_manager=event_manager)
 
     yield
 
     await labeled_butler_factory_dependency.aclose()
     await obscore_config_dependency.aclose()
-    await context_dependency.aclose()
     await event_manager.aclose()
     await http_client_dependency.aclose()
     logger.debug("SIA shut down complete.")

--- a/src/sia/services/data_collections.py
+++ b/src/sia/services/data_collections.py
@@ -1,17 +1,11 @@
 """Data collection helper service."""
 
-from dataclasses import dataclass
-
-from ..config import Config
+from ..config import config
 from ..models.data_collections import ButlerDataCollection
 
 
-@dataclass
 class DataCollectionService:
     """Data Collection service class."""
-
-    config: Config
-    """The configuration object for the data collection."""
 
     def _get_data_collection(
         self,
@@ -46,7 +40,7 @@ class DataCollectionService:
         if not value:
             raise ValueError(f"{key.capitalize()} is required.")
 
-        for collection in self.config.butler_data_collections:
+        for collection in config.butler_data_collections:
             if getattr(collection, attribute).upper() == value.upper():
                 return collection
 
@@ -123,7 +117,7 @@ class DataCollectionService:
         """
         butler_repos = {}
 
-        for collection in self.config.butler_data_collections:
+        for collection in config.butler_data_collections:
             label = collection.label
             repository = collection.repository
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,10 +34,27 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _config(data: SiaData, monkeypatch: pytest.MonkeyPatch) -> Config:
+    """Override configuration to use remote Butler."""
+    butler_collections = [
+        ButlerDataCollection(
+            config=data.path("config/dp02.yaml"),
+            label="LSST.DP02",
+            name="dp02",
+            butler_type=ButlerType.REMOTE,
+            repository=HttpUrl(
+                "https://example.com/api/butler/repo/dp02/butler.yaml"
+            ),
+        ),
+    ]
+    monkeypatch.setattr(config, "path_prefix", "/api/sia")
+    monkeypatch.setattr(config, "butler_data_collections", butler_collections)
+    return config
+
+
 @pytest_asyncio.fixture
-async def app(
-    data: SiaData, monkeypatch: pytest.MonkeyPatch
-) -> AsyncGenerator[FastAPI]:
+async def app() -> AsyncGenerator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
@@ -63,18 +80,6 @@ async def app(
         form_data = await request.form()
         return {"method": "POST", "form_data": dict(form_data)}
 
-    butler_collections = [
-        ButlerDataCollection(
-            config=data.path("config/dp02.yaml"),
-            label="LSST.DP02",
-            name="dp02",
-            butler_type=ButlerType.REMOTE,
-            repository=HttpUrl("https://example/repo/dp02/butler.yaml"),
-        ),
-    ]
-    monkeypatch.setattr(config, "path_prefix", "/api/sia")
-    monkeypatch.setattr(config, "butler_data_collections", butler_collections)
-
     async with LifespanManager(main.app):
         yield main.app
 
@@ -97,32 +102,6 @@ async def client(app: FastAPI) -> AsyncGenerator[AsyncClient]:
 def data(request: pytest.FixtureRequest) -> SiaData:
     update = request.config.getoption("--update-test-data")
     return SiaData(Path(__file__).parent / "data", update_test_data=update)
-
-
-@pytest_asyncio.fixture
-async def test_config(data: SiaData) -> Config:
-    """Return a test configuration for a remote Butler.
-
-    Returns
-    -------
-    Config
-        The test configuration
-    """
-    butler_collections = [
-        ButlerDataCollection(
-            config=data.path("config/dp02.yaml"),
-            label="LSST.DP02",
-            name="dp02",
-            repository=HttpUrl(
-                "https://example.com/api/butler/repo/dp02/butler.yaml"
-            ),
-            butler_type=ButlerType.REMOTE,
-        ),
-    ]
-    return Config(
-        path_prefix="/api/sia",
-        butler_data_collections=butler_collections,
-    )
 
 
 @pytest.fixture

--- a/tests/handlers/external/availability_test.py
+++ b/tests/handlers/external/availability_test.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from httpx import AsyncClient
 
-from sia.config import Config, config
+from sia.config import config
 from sia.services.availability import AvailabilityService
 from sia.services.data_collections import DataCollectionService
 
@@ -28,13 +28,11 @@ async def test_availability(
 
 
 @pytest.mark.asyncio
-async def test_remote_butler_availability_success(
-    test_config: Config,
-) -> None:
+async def test_remote_butler_availability_success() -> None:
     """Test the availability of the remote Butler ."""
-    collection = DataCollectionService(
-        config=test_config
-    ).get_data_collection_by_name(name="dp02")
+    collection = DataCollectionService().get_data_collection_by_name(
+        name="dp02"
+    )
 
     checker = AvailabilityService(collection)
     with patch("sia.services.availability.AsyncClient") as mock_client:
@@ -48,15 +46,13 @@ async def test_remote_butler_availability_success(
 
 
 @pytest.mark.asyncio
-async def test_remote_butler_availability_failure(
-    test_config: Config,
-) -> None:
+async def test_remote_butler_availability_failure() -> None:
     """Test the availability of the remote Butler  when
     it is not available.
     """
-    collection = DataCollectionService(
-        config=test_config
-    ).get_data_collection_by_name(name="dp02")
+    collection = DataCollectionService().get_data_collection_by_name(
+        name="dp02"
+    )
 
     checker = AvailabilityService(collection)
     with patch("sia.services.availability.AsyncClient") as mock_client:

--- a/tests/models/config_test.py
+++ b/tests/models/config_test.py
@@ -12,9 +12,7 @@ from sia.models.data_collections import ButlerDataCollection
 
 
 @pytest.mark.asyncio
-async def test_empty_config(
-    test_config: Config, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_empty_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that an empty Config raises a FatalFaultError."""
     monkeypatch.setenv("SIA_BUTLER_DATA_COLLECTIONS", "")
 
@@ -27,9 +25,7 @@ async def test_empty_config(
 
 
 @pytest.mark.asyncio
-async def test_config_no_butler_type(
-    test_config: Config, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_config_no_butler_type(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that a Config with no default collection raises a
     FatalFaultError.
     """

--- a/tests/services/data_collection_test.py
+++ b/tests/services/data_collection_test.py
@@ -5,19 +5,17 @@ import re
 import pytest
 from pydantic import HttpUrl
 
-from sia.config import Config
-from sia.exceptions import FatalFaultError
 from sia.services.data_collections import DataCollectionService
 
 
 @pytest.mark.asyncio
-async def test_get_data_repositories(test_config: Config) -> None:
+async def test_get_data_repositories() -> None:
     """Test get_data_repositories function."""
     expected_repos = {
         "LSST.DP02": "https://example.com/api/butler/repo/dp02/butler.yaml"
     }
 
-    result = DataCollectionService(config=test_config).get_data_repositories()
+    result = DataCollectionService().get_data_repositories()
 
     assert result == expected_repos, (
         f"Expected {expected_repos}, but got {result}"
@@ -30,14 +28,10 @@ async def test_get_data_repositories(test_config: Config) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_data_collection_with_label(
-    test_config: Config,
-) -> None:
+async def test_get_data_collection_with_label() -> None:
     """Test get_data_collection function with a label."""
     label = "LSST.DP02"
-    result = DataCollectionService(
-        config=test_config
-    ).get_data_collection_by_label(label=label)
+    result = DataCollectionService().get_data_collection_by_label(label=label)
     assert result.label == label
     assert result.repository == HttpUrl(
         "https://example.com/api/butler/repo/dp02/butler.yaml"
@@ -45,14 +39,10 @@ async def test_get_data_collection_with_label(
 
 
 @pytest.mark.asyncio
-async def test_get_data_collection_with_name(
-    test_config: Config,
-) -> None:
+async def test_get_data_collection_with_name() -> None:
     """Test get_data_collection function with a name."""
     name = "dp02"
-    result = DataCollectionService(
-        config=test_config
-    ).get_data_collection_by_name(name=name)
+    result = DataCollectionService().get_data_collection_by_name(name=name)
     assert result.name == name
     assert result.repository == HttpUrl(
         "https://example.com/api/butler/repo/dp02/butler.yaml"
@@ -60,46 +50,22 @@ async def test_get_data_collection_with_name(
 
 
 @pytest.mark.asyncio
-async def test_get_data_collection_no_label(
-    test_config: Config,
-) -> None:
+async def test_get_data_collection_no_label() -> None:
     """Test get_data_collection function with no label."""
     with pytest.raises(
         ValueError,
         match=re.escape("Label is required."),
     ):
-        DataCollectionService(config=test_config).get_data_collection_by_label(
-            label=""
-        )
+        DataCollectionService().get_data_collection_by_label(label="")
 
 
 @pytest.mark.asyncio
-async def test_get_data_collection_empty_config() -> None:
-    """Test get_data_collection function with an empty configuration."""
-    with pytest.raises(
-        FatalFaultError,
-        match=re.escape(
-            "FatalFault: No Data Collections configured. Please configure "
-            "at least one Data collection."
-        ),
-    ):
-        empty_config = Config(
-            butler_data_collections=[],
-        )
-        DataCollectionService(
-            config=empty_config
-        ).get_data_collection_by_label(label="")
-
-
-@pytest.mark.asyncio
-async def test_get_data_collection_invalid_label(
-    test_config: Config,
-) -> None:
+async def test_get_data_collection_invalid_label() -> None:
     """Test get_data_collection function with an invalid label."""
     with pytest.raises(
         KeyError,
         match="Label InvalidLabel not found in Data collections",
     ):
-        DataCollectionService(config=test_config).get_data_collection_by_label(
+        DataCollectionService().get_data_collection_by_label(
             label="InvalidLabel"
         )


### PR DESCRIPTION
SIA configures itself from environment variables on startup, so there's one global config object. Some places were using that and some were passing `config` around as a parameter. Standardize on using the global object and simplify the other code.