### PR TITLE
DM-55537: Get the DataLink links URL from service discovery

### DIFF
--- a/changelog.d/20260722_151018_rra_DM_55537_queue.md
+++ b/changelog.d/20260722_151018_rra_DM_55537_queue.md
@@ -1,0 +1,3 @@
+### New features
+
+- Get the DataLink links URL for a given Butler dataset from service discovery rather than requiring it be set in the SIA configuration.

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -33,11 +33,6 @@ butlerDataCollections
 
     Example: ``"REMOTE"``
 
-**datalink_url** (optional)
-    An HTTP path to overwrite the Datalink endpoint in the obscore repository with.
-
-    Example: ``"https://data-dev.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"``.
-
 Ingresses
 ==================
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,11 +16,7 @@ nox.options.default_venv_backend = "uv"
 nox.options.reuse_existing_virtualenvs = True
 
 # Value of SIA_BUTLER_DATA_COLLECTIONS for testing.
-_COLLECTIONS = (
-    '[{"config":"https://example.com/dp02.yaml", '
-    '"datalink_url":"https://example.com/links?ID=butler%3A//dp02", '
-    '"name":"dp02"}]'
-)
+_COLLECTIONS = '[{"config":"https://example.com/dp02.yaml", "name":"dp02"}]'
 
 
 @session(name="coverage-report", requires=["test"], uv_groups=["dev"])

--- a/src/sia/constants.py
+++ b/src/sia/constants.py
@@ -2,22 +2,23 @@
 
 __all__ = [
     "BASE_RESOURCE_IDENTIFIER",
+    "DATALINK_VERSION",
     "RESPONSEFORMATS",
     "RESULT_NAME",
     "SINGLE_PARAMS",
 ]
 
-RESPONSEFORMATS = {"votable", "application/x-votable"}
-"""List of supported response formats for the SIA service."""
-
-RESULT_NAME = "result"
-"""The name of the result file."""
-
-SINGLE_PARAMS = {
-    "maxrec",
-    "responseformat",
-}
-"""Parameters that should be treated as single values."""
-
 BASE_RESOURCE_IDENTIFIER = "ivo://rubin/"
 """The base resource identifier for any rubin SIA service."""
+
+DATALINK_VERSION = "datalink-links-1.1"
+"""Version of the DataLink links service to request from service discovery."""
+
+RESPONSEFORMATS = {"votable", "application/x-votable"}
+"""Set of supported response formats for the SIA service."""
+
+RESULT_NAME = "result"
+"""Name of the result file."""
+
+SINGLE_PARAMS = {"maxrec", "responseformat"}
+"""Parameters that should be treated as single values."""

--- a/src/sia/dependencies/context.py
+++ b/src/sia/dependencies/context.py
@@ -17,7 +17,6 @@ from structlog.stdlib import BoundLogger
 from ..events import Events
 from ..factory import Factory
 from .labeled_butler_factory import labeled_butler_factory_dependency
-from .obscore_configs import obscore_config_dependency
 
 __all__ = [
     "ContextDependency",
@@ -81,20 +80,15 @@ class ContextDependency:
         """Create a per-request context and return it."""
         if not self._events:
             raise RuntimeError("ContextDependency not initialized")
-
+        factory = Factory(
+            logger=logger,
+            labeled_butler_factory=await labeled_butler_factory_dependency(),
+        )
         return RequestContext(
             request=request,
             logger=logger,
-            factory=await self.create_factory(logger=logger),
+            factory=factory,
             events=self._events,
-        )
-
-    async def create_factory(self, logger: BoundLogger) -> Factory:
-        """Create a factory for use outside a request context."""
-        return Factory(
-            logger=logger,
-            labeled_butler_factory=await labeled_butler_factory_dependency(),
-            obscore_configs=await obscore_config_dependency(),
         )
 
     async def initialize(self, event_manager: EventManager) -> None:

--- a/src/sia/dependencies/obscore_configs.py
+++ b/src/sia/dependencies/obscore_configs.py
@@ -1,36 +1,89 @@
 """Dependency class for loading the Obscore configs."""
 
-from lsst.dax.obscore import ExporterConfig
+import contextlib
+from typing import Annotated
+from urllib.parse import urlparse, urlunparse
 
-from ..config import config
+from fastapi import Depends
+from lsst.daf.butler import ButlerConfig
+from lsst.dax.obscore import ExporterConfig
+from rubin.repertoire import DiscoveryClient, discovery_dependency
+
+from ..constants import DATALINK_VERSION
+from ..models.data_collections import ButlerDataCollection
+from .data_collections import validate_collection
+
+__all__ = [
+    "ObscoreConfigDependency",
+    "datalink_url_dependency",
+    "obscore_config_dependency",
+]
+
+
+async def datalink_url_dependency(
+    collection: Annotated[ButlerDataCollection, Depends(validate_collection)],
+    discovery: Annotated[DiscoveryClient, Depends(discovery_dependency)],
+) -> str | None:
+    """Determine the DataLink links URL for a collection.
+
+    This is a separate dependency from `ObsCoreConfigDependency` because the
+    latter cannot run async since it makes HTTP requests with a sync
+    underlying library.
+    """
+    return await discovery.url_for_data(
+        "datalink", collection.name, version=DATALINK_VERSION
+    )
 
 
 class ObscoreConfigDependency:
-    """Provides a mapping of label names to Obscore (Exporter) Configs as a
-    dependency.
-    """
+    """Retrieve ObsCore exporter configuration for a collection."""
 
     def __init__(self) -> None:
-        self._config_mapping: dict[str, ExporterConfig] | None = None
+        self._cache: dict[str, ExporterConfig] = {}
+        self._datalink_urls: dict[str, str | None] = {}
 
-    async def initialize(self) -> None:
-        """Initialize the dependency by processing the Butler Collections."""
-        self._config_mapping = {}
-        for collection in config.butler_data_collections:
-            exporter_config = collection.get_exporter_config()
-            self._config_mapping[collection.name] = exporter_config
+    def __call__(
+        self,
+        datalink_url: Annotated[str | None, Depends(datalink_url_dependency)],
+        collection: Annotated[
+            ButlerDataCollection, Depends(validate_collection)
+        ],
+    ) -> ExporterConfig:
+        """Get the ObsCore exporter configuration for a collection."""
+        name = collection.name
+        exporter_config = self._cache.get(name)
+        if exporter_config and self._datalink_urls.get(name) == datalink_url:
+            return exporter_config
 
-    async def __call__(self) -> dict[str, ExporterConfig]:
-        """Return the mapping of names to ExporterConfigs."""
-        if self._config_mapping is None:
-            raise RuntimeError("ExporterConfigDependency is not initialized")
-        return self._config_mapping
+        # Fetch the ObsCore configuration and create the appropriate model.
+        config_data = ButlerConfig(str(collection.config))
+        exporter_config = ExporterConfig.model_validate(config_data)
 
-    async def aclose(self) -> None:
-        """Clear the config mapping."""
-        self._config_mapping = None
+        # We normally should find the datalink_url_fmt attribute for each
+        # dataset type. If it doesn't exist this doesn't seem to be a critical
+        # issue so we suppress the AttributeError. Otherwise, preserve its
+        # query arguments, but replace the rest of the URL with the URL from
+        # service discovery.
+        if datalink_url:
+            new_url = urlparse(datalink_url)
+            new_netloc = new_url.hostname or ""
+            if new_url.port:
+                new_netloc = f"{new_netloc}:{new_url.port}"
+            for settings in exporter_config.dataset_types.values():
+                with contextlib.suppress(AttributeError):
+                    old_url = urlparse(str(settings.datalink_url_fmt))
+                    merged_url = old_url._replace(
+                        scheme=new_url.scheme,
+                        netloc=new_netloc,
+                        path=new_url.path,
+                    )
+                    settings.datalink_url_fmt = urlunparse(merged_url)
+
+        # Update the cache and return the results.
+        self._cache[name] = exporter_config
+        self._datalink_urls[name] = datalink_url
+        return exporter_config
 
 
 obscore_config_dependency = ObscoreConfigDependency()
-"""The dependency that will return the mapping of label names to
-Obscore Configs."""
+"""Return the ObsCore exporter config for a given collection."""

--- a/src/sia/dependencies/obscore_configs.py
+++ b/src/sia/dependencies/obscore_configs.py
@@ -1,6 +1,5 @@
 """Dependency class for loading the Obscore configs."""
 
-import contextlib
 from typing import Annotated
 from urllib.parse import urlparse, urlunparse
 
@@ -70,7 +69,7 @@ class ObscoreConfigDependency:
             if new_url.port:
                 new_netloc = f"{new_netloc}:{new_url.port}"
             for settings in exporter_config.dataset_types.values():
-                with contextlib.suppress(AttributeError):
+                if settings.datalink_url_fmt:
                     old_url = urlparse(str(settings.datalink_url_fmt))
                     merged_url = old_url._replace(
                         scheme=new_url.scheme,

--- a/src/sia/factory.py
+++ b/src/sia/factory.py
@@ -2,7 +2,6 @@
 
 import structlog
 from lsst.daf.butler import Butler, LabeledButlerFactory
-from lsst.dax.obscore import ExporterConfig
 from structlog.stdlib import BoundLogger
 
 from .config import config
@@ -31,11 +30,9 @@ class Factory:
     def __init__(
         self,
         labeled_butler_factory: LabeledButlerFactory,
-        obscore_configs: dict[str, ExporterConfig],
         logger: BoundLogger | None = None,
     ) -> None:
         self._labeled_butler_factory = labeled_butler_factory
-        self._obscore_configs = obscore_configs
         self._logger = logger or structlog.get_logger(config.name)
 
     def create_butler(
@@ -60,21 +57,6 @@ class Factory:
         return self._labeled_butler_factory.create_butler(
             label=butler_collection.name, access_token=token
         )
-
-    def create_obscore_config(self, label: str) -> ExporterConfig:
-        """Create an Obscore config object for a given label.
-
-        Parameters
-        ----------
-        label
-            The label for the Obscore config.
-
-        Returns
-        -------
-        ExporterConfig
-            The Obscore config.
-        """
-        return self._obscore_configs[label]
 
     def create_data_collection_service(self) -> DataCollectionService:
         """Create a data collection service.

--- a/src/sia/handlers/external.py
+++ b/src/sia/handlers/external.py
@@ -5,6 +5,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.templating import Jinja2Templates
+from lsst.dax.obscore import ExporterConfig
 from lsst.dax.obscore.siav2 import siav2_query
 from safir.dependencies.gafaelfawr import (
     auth_delegated_token_dependency,
@@ -20,6 +21,7 @@ from vo_models.vosi.capabilities.models import VOSICapabilities
 from ..config import config
 from ..dependencies.context import RequestContext, context_dependency
 from ..dependencies.data_collections import validate_collection
+from ..dependencies.obscore_configs import obscore_config_dependency
 from ..dependencies.query_params import get_sia_params_dependency
 from ..models.data_collections import ButlerDataCollection
 from ..models.index import Index
@@ -184,6 +186,9 @@ async def get_capabilities(
 async def query(
     *,
     context: Annotated[RequestContext, Depends(context_dependency)],
+    obscore_config: Annotated[
+        ExporterConfig, Depends(obscore_config_dependency)
+    ],
     collection: Annotated[ButlerDataCollection, Depends(validate_collection)],
     raw_params: Annotated[SIAQueryParams, Depends(get_sia_params_dependency)],
     user: Annotated[str, Depends(auth_dependency)],
@@ -198,4 +203,5 @@ async def query(
         events=context.events,
         user=user,
         request=context.request,
+        obscore_config=obscore_config,
     )

--- a/src/sia/main.py
+++ b/src/sia/main.py
@@ -16,6 +16,7 @@ import structlog
 from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.openapi.utils import get_openapi
+from rubin.repertoire import discovery_dependency
 from safir.dependencies.http_client import http_client_dependency
 from safir.logging import configure_logging, configure_uvicorn_logging
 from safir.middleware.ivoa import (
@@ -28,7 +29,6 @@ from safir.slack.webhook import SlackRouteErrorHandler
 from . import __version__
 from .config import config
 from .dependencies.context import context_dependency
-from .dependencies.obscore_configs import obscore_config_dependency
 from .errors import votable_exception_handler
 from .exceptions import VOTableError
 from .handlers.external import external_router
@@ -46,14 +46,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Set up and tear down the application."""
     logger = structlog.get_logger("sia")
     logger.debug("SIA has started up.")
-    await obscore_config_dependency.initialize()
+    discovery_dependency.initialize(logger)
     event_manager = config.metrics.make_manager()
     await event_manager.initialize()
     await context_dependency.initialize(event_manager=event_manager)
 
     yield
 
-    await obscore_config_dependency.aclose()
     await event_manager.aclose()
     await http_client_dependency.aclose()
     logger.debug("SIA shut down complete.")

--- a/src/sia/models/data_collections.py
+++ b/src/sia/models/data_collections.py
@@ -1,12 +1,9 @@
 """Data collection models."""
 
-import contextlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated
 
-from lsst.daf.butler import ButlerConfig
-from lsst.dax.obscore import ExporterConfig
 from pydantic import Field, HttpUrl
 
 
@@ -38,37 +35,3 @@ class ButlerDataCollection:
             examples=["dp02"],
         ),
     ]
-
-    datalink_url: Annotated[
-        HttpUrl | None,
-        Field(
-            default=None,
-            title="DataLink URL",
-            description=(
-                "An optional datalink URL to use instead of the one in the"
-                " config. This will overwrite the value in the obscore"
-                " configuration for the collection"
-            ),
-        ),
-    ] = None
-
-    def get_exporter_config(self) -> ExporterConfig:
-        """Get the exporter configuration.
-
-        Returns
-        -------
-        ExporterConfig
-            The exporter configuration.
-        """
-        config_data = ButlerConfig(str(self.config))
-        exporter_config = ExporterConfig.model_validate(config_data)
-        # Overwrite datalink format if provided
-        for name in exporter_config.dataset_types:
-            with contextlib.suppress(AttributeError):
-                # We normally should find the datalink_url_fmt attribute
-                # If it doesn't exist this doesn't seem to be a critical issue
-                # so we suppress the AttributeError
-                exporter_config.dataset_types[name].datalink_url_fmt = str(
-                    self.datalink_url
-                )
-        return exporter_config

--- a/src/sia/services/response_handler.py
+++ b/src/sia/services/response_handler.py
@@ -159,6 +159,7 @@ class ResponseHandlerService:
         events: Events,
         user: str,
         token: str,
+        obscore_config: ExporterConfig,
     ) -> Response:
         """Process the SIAv2 query and generate a Response.
 
@@ -180,6 +181,8 @@ class ResponseHandlerService:
             The username.
         token
             The token to use for the Butler.
+        obscore_config
+            The ObsCore configuration.
 
         Returns
         -------
@@ -208,7 +211,6 @@ class ResponseHandlerService:
                 token=token,
             ),
         )
-        obscore_config = factory.create_obscore_config(collection.name)
 
         if params.maxrec == 0:
             logger.info(

--- a/tests/dependencies/obscore_configs_test.py
+++ b/tests/dependencies/obscore_configs_test.py
@@ -1,0 +1,36 @@
+"""Tests for SIA FastAPI dependencies."""
+
+from typing import Annotated
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import AsyncClient
+from lsst.dax.obscore import ExporterConfig
+from rubin.repertoire import Discovery
+
+from sia.constants import DATALINK_VERSION
+from sia.dependencies.obscore_configs import obscore_config_dependency
+
+
+@pytest.mark.asyncio
+async def test_obscore_config(
+    app: FastAPI, client: AsyncClient, mock_discovery: Discovery
+) -> None:
+    """Test that the DataLink URL is replaced in the ObsCore config."""
+    datalink = mock_discovery.datasets["dp02"].services["datalink"]
+    datalink_url = str(datalink.versions[DATALINK_VERSION].url)
+
+    @app.get("/{collection_name}/test-obscore")
+    async def obscore(
+        obscore_config: Annotated[
+            ExporterConfig, Depends(obscore_config_dependency)
+        ],
+    ) -> ExporterConfig:
+        return obscore_config
+
+    r = await client.get("/dp02/test-obscore")
+    assert r.status_code == 200
+    exporter_config = ExporterConfig.model_validate(r.json())
+    for settings in exporter_config.dataset_types.values():
+        assert settings.datalink_url_fmt
+        assert settings.datalink_url_fmt.startswith(datalink_url + "?")


### PR DESCRIPTION
Use Repertoire to get the DataLink links URL for a given dataset rather than requiring it be provided in the SIA configuration. This change required some surgery to the dependency structure to query service discovery on every request and only use a cached copy of the ObsCore exporter configuration if the service discovery results have not changed.