### PR TITLE
DM-55537: Move Butler creation into a dependency

### DIFF
--- a/src/sia/dependencies/butler.py
+++ b/src/sia/dependencies/butler.py
@@ -1,14 +1,30 @@
-"""Dependency class for creating a LabeledButlerFactory singleton."""
+"""Dependency class for creating Butler instances."""
 
-from lsst.daf.butler import LabeledButlerFactory
+from typing import Annotated
+
+from fastapi import Depends
+from lsst.daf.butler import Butler, LabeledButlerFactory
 from rubin.repertoire import DiscoveryClient
+from safir.dependencies.gafaelfawr import auth_delegated_token_dependency
 
 from ..config import config
 from ..exceptions import FatalFaultError
+from ..models.data_collections import ButlerDataCollection
+from .data_collections import validate_collection
+
+__all__ = [
+    "ButlerFactoryDependency",
+    "butler_dependency",
+    "butler_factory_dependency",
+]
 
 
-class LabeledButlerFactoryDependency:
-    """Provides a remote butler factory as a dependency."""
+class ButlerFactoryDependency:
+    """Provides a labeled Butler factory as a dependency.
+
+    This factory will be configured with the labels that SIA knows about. It
+    is normally used via `butler_factory_dependency`.
+    """
 
     def __init__(self) -> None:
         self._discovery = DiscoveryClient()
@@ -57,5 +73,22 @@ class LabeledButlerFactoryDependency:
         return self._butler_factory
 
 
-labeled_butler_factory_dependency = LabeledButlerFactoryDependency()
-"""The dependency that will return the LabeledButlerFactoryDependency."""
+butler_factory_dependency = ButlerFactoryDependency()
+"""Dependency that returns a Butler factory that knows about dataset labels."""
+
+
+def butler_dependency(
+    butler_factory: Annotated[
+        LabeledButlerFactory, Depends(butler_factory_dependency)
+    ],
+    collection: Annotated[ButlerDataCollection, Depends(validate_collection)],
+    token: Annotated[str, Depends(auth_delegated_token_dependency)],
+) -> Butler:
+    """Construct a Butler for a given collection and user token.
+
+    This function should be sync rather than async in case constructing a
+    Butler requires network I/O. FastAPI will then run it in a thread pool
+    rather than blocking the main process.
+    """
+    name = collection.name
+    return butler_factory.create_butler(label=name, access_token=token)

--- a/src/sia/dependencies/context.py
+++ b/src/sia/dependencies/context.py
@@ -16,7 +16,6 @@ from structlog.stdlib import BoundLogger
 
 from ..events import Events
 from ..factory import Factory
-from .labeled_butler_factory import labeled_butler_factory_dependency
 
 __all__ = [
     "ContextDependency",
@@ -80,10 +79,7 @@ class ContextDependency:
         """Create a per-request context and return it."""
         if not self._events:
             raise RuntimeError("ContextDependency not initialized")
-        factory = Factory(
-            logger=logger,
-            labeled_butler_factory=await labeled_butler_factory_dependency(),
-        )
+        factory = Factory(logger=logger)
         return RequestContext(
             request=request,
             logger=logger,

--- a/src/sia/factory.py
+++ b/src/sia/factory.py
@@ -1,11 +1,9 @@
 """Component factory and process-wide status for sia."""
 
 import structlog
-from lsst.daf.butler import Butler, LabeledButlerFactory
 from structlog.stdlib import BoundLogger
 
 from .config import config
-from .models.data_collections import ButlerDataCollection
 
 __all__ = ["Factory"]
 
@@ -18,44 +16,12 @@ class Factory:
 
     Parameters
     ----------
-    labeled_butler_factory
-        The LabeledButlerFactory singleton
-    obscore_configs
-        The Obscore configurations
     logger
         The logger instance
     """
 
-    def __init__(
-        self,
-        labeled_butler_factory: LabeledButlerFactory,
-        logger: BoundLogger | None = None,
-    ) -> None:
-        self._labeled_butler_factory = labeled_butler_factory
+    def __init__(self, logger: BoundLogger | None = None) -> None:
         self._logger = logger or structlog.get_logger(config.name)
-
-    def create_butler(
-        self,
-        butler_collection: ButlerDataCollection,
-        token: str,
-    ) -> Butler:
-        """Create a Butler instance.
-
-        Parameters
-        ----------
-        butler_collection
-            The Butler data collection.
-        token
-            The token to use for the Butler instance.
-
-        Returns
-        -------
-        Butler
-            The Butler instance.
-        """
-        return self._labeled_butler_factory.create_butler(
-            label=butler_collection.name, access_token=token
-        )
 
     def set_logger(self, logger: BoundLogger) -> None:
         """Replace the internal logger.

--- a/src/sia/handlers/external.py
+++ b/src/sia/handlers/external.py
@@ -5,12 +5,10 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.templating import Jinja2Templates
+from lsst.daf.butler import Butler
 from lsst.dax.obscore import ExporterConfig
 from lsst.dax.obscore.siav2 import siav2_query
-from safir.dependencies.gafaelfawr import (
-    auth_delegated_token_dependency,
-    auth_dependency,
-)
+from safir.dependencies.gafaelfawr import auth_dependency
 from safir.dependencies.logger import logger_dependency
 from safir.metadata import get_metadata
 from safir.models import ErrorModel
@@ -19,6 +17,7 @@ from vo_models.vosi.availability import Availability
 from vo_models.vosi.capabilities.models import VOSICapabilities
 
 from ..config import config
+from ..dependencies.butler import butler_dependency
 from ..dependencies.context import RequestContext, context_dependency
 from ..dependencies.data_collections import validate_collection
 from ..dependencies.obscore_configs import obscore_config_dependency
@@ -180,18 +179,17 @@ async def get_capabilities(
 async def query(
     *,
     context: Annotated[RequestContext, Depends(context_dependency)],
+    butler: Annotated[Butler, Depends(butler_dependency)],
     obscore_config: Annotated[
         ExporterConfig, Depends(obscore_config_dependency)
     ],
     collection: Annotated[ButlerDataCollection, Depends(validate_collection)],
     raw_params: Annotated[SIAQueryParams, Depends(get_sia_params_dependency)],
     user: Annotated[str, Depends(auth_dependency)],
-    token: Annotated[str, Depends(auth_delegated_token_dependency)],
 ) -> Response:
     return await ResponseHandlerService.process_query(
-        factory=context.factory,
+        butler=butler,
         raw_params=raw_params,
-        token=token,
         sia_query=siav2_query,
         collection=collection,
         events=context.events,

--- a/src/sia/services/availability.py
+++ b/src/sia/services/availability.py
@@ -3,9 +3,7 @@
 from httpx import AsyncClient, HTTPError
 from vo_models.vosi.availability import Availability
 
-from ..dependencies.labeled_butler_factory import (
-    labeled_butler_factory_dependency,
-)
+from ..dependencies.butler import butler_factory_dependency
 from ..models.data_collections import ButlerDataCollection
 
 
@@ -23,9 +21,8 @@ class AvailabilityService:
         Availability
             The availability of the service.
         """
-        butler_url = await labeled_butler_factory_dependency.get_butler_url(
-            self._collection.name
-        )
+        name = self._collection.name
+        butler_url = await butler_factory_dependency.get_butler_url(name)
         if not butler_url:
             note = f"Unknown collection {self._collection.name}"
             return Availability(note=[note], available=False)

--- a/src/sia/services/response_handler.py
+++ b/src/sia/services/response_handler.py
@@ -17,7 +17,6 @@ from safir.sentry import duration
 from ..constants import BASE_RESOURCE_IDENTIFIER
 from ..constants import RESULT_NAME as RESULT
 from ..events import Events, SIAQueryFailed, SIAQuerySucceeded
-from ..factory import Factory
 from ..models.data_collections import ButlerDataCollection
 from ..models.sia_query_params import BandInfo, SIAQueryParams
 from ..sentry import capturing_start_span
@@ -151,22 +150,21 @@ class ResponseHandlerService:
     @staticmethod
     async def process_query(
         *,
-        factory: Factory,
+        butler: Butler,
         raw_params: SIAQueryParams,
         sia_query: SIAv2QueryType,
         request: Request,
         collection: ButlerDataCollection,
         events: Events,
         user: str,
-        token: str,
         obscore_config: ExporterConfig,
     ) -> Response:
         """Process the SIAv2 query and generate a Response.
 
         Parameters
         ----------
-        factory
-            The Factory instance.
+        butler
+            Butler client to use.
         raw_params
             The parameters for the SIAv2 query.
         sia_query
@@ -179,8 +177,6 @@ class ResponseHandlerService:
             Object with attributes for all metrics event publishers.
         user
             The username.
-        token
-            The token to use for the Butler.
         obscore_config
             The ObsCore configuration.
 
@@ -202,15 +198,6 @@ class ResponseHandlerService:
         )
 
         loop = asyncio.get_running_loop()
-
-        # Run Butler creation in a thread pool
-        butler = await loop.run_in_executor(
-            None,
-            lambda: factory.create_butler(
-                butler_collection=collection,
-                token=token,
-            ),
-        )
 
         if params.maxrec == 0:
             logger.info(


### PR DESCRIPTION
Create a new `butler_dependency` that creates a Butler for the collection and token of a request. Pass that into the request handler rather than the factory and strip the Butler creation out of the factory in preparation for repurposing the factory to create higher-level service objects with their per-request context.