### PR TITLE
DM-55537: Use full checkout for periodic CI

### DIFF
--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -23,6 +23,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Ensure the documentation gets the right version.
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Sphinx requires a full Git checkout to get last modification dates, so do a full checkout for the periodic CI checks.